### PR TITLE
Call update_median_feeds and check_call_orders when bitasset changes

### DIFF
--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -407,13 +407,14 @@ void_result asset_update_bitasset_evaluator::do_evaluate(const asset_update_bita
  * @param db the database
  * @param bdo the actual database object
  * @param asset_to_update the asset_object related to this bitasset_data_object
- * @returns true if the feed price is changed
+ * @returns true if the feed price is changed, and after hf 890
  */
 static bool update_bitasset_object_options(
       const asset_update_bitasset_operation& op, database& db,
-      asset_bitasset_data_object& bdo, const asset_object& asset_to_update,
-      const fc::time_point_sec& next_maint_time )
+      asset_bitasset_data_object& bdo, const asset_object& asset_to_update)
 {
+   const fc::time_point_sec& next_maint_time = db.get_dynamic_global_properties().next_maintenance_time;
+
    // If the minimum number of feeds to calculate a median has changed
    // we need to recalculate the median
    bool should_update_feeds = false;
@@ -465,7 +466,7 @@ static bool update_bitasset_object_options(
    if( should_update_feeds )
       bdo.update_median_feeds(db.head_block_time());
 
-   return old_feed_price != bdo.current_feed.settlement_price;
+   return next_maint_time > HARDFORK_CORE_890_TIME && old_feed_price != bdo.current_feed.settlement_price;
 }
 
 void_result asset_update_bitasset_evaluator::do_apply(const asset_update_bitasset_operation& op)
@@ -473,15 +474,14 @@ void_result asset_update_bitasset_evaluator::do_apply(const asset_update_bitasse
    try
    {
       auto& db_conn = db();
-      const fc::time_point_sec& next_maint_time = db_conn.get_dynamic_global_properties().next_maintenance_time;
       const auto& asset_being_updated = (*asset_to_update);
       bool price_changed = false;
 
-      db().modify(*bitasset_to_update, [&op, &asset_being_updated, &price_changed, &next_maint_time, &db_conn](asset_bitasset_data_object& bdo) {
-         price_changed = update_bitasset_object_options(op, db_conn, bdo, asset_being_updated, next_maint_time);
+      db_conn.modify(*bitasset_to_update, [&op, &asset_being_updated, &price_changed, &db_conn](asset_bitasset_data_object& bdo) {
+         price_changed = update_bitasset_object_options(op, db_conn, bdo, asset_being_updated);
       });
 
-      if (next_maint_time >= HARDFORK_CORE_890_TIME && price_changed)
+      if (price_changed)
          db_conn.check_call_orders(asset_being_updated);
 
       return void_result();

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -462,11 +462,17 @@ static bool update_bitasset_object_options(
       }
    }
 
-   const auto old_feed_price = bdo.current_feed.settlement_price;
    if( should_update_feeds )
+   {
+      const auto old_feed_price = bdo.current_feed.settlement_price;
       bdo.update_median_feeds(db.head_block_time());
 
-   return next_maint_time > HARDFORK_CORE_890_TIME && old_feed_price != bdo.current_feed.settlement_price;
+      return next_maint_time > HARDFORK_CORE_890_TIME && old_feed_price != bdo.current_feed.settlement_price;
+   }
+   else
+   {
+      return false;
+   }
 }
 
 void_result asset_update_bitasset_evaluator::do_apply(const asset_update_bitasset_operation& op)

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -422,7 +422,8 @@ static bool update_bitasset_object_options(
       should_update_feeds = true;
 
    // We need to call check_call_orders if the settlement price changes after hardfork 890
-   if (next_maint_time > HARDFORK_CORE_890_TIME) {
+   if (next_maint_time > HARDFORK_CORE_890_TIME)
+   {
       // after hardfork 890, we also should call update_median_feeds
       // if the feed_lifetime_sec changed
       if (op.new_options.feed_lifetime_sec != bdo.options.feed_lifetime_sec)

--- a/libraries/chain/asset_object.cpp
+++ b/libraries/chain/asset_object.cpp
@@ -43,10 +43,19 @@ share_type asset_bitasset_data_object::max_force_settlement_volume(share_type cu
    return volume.to_uint64();
 }
 
+/******
+ * @brief calculate the median feed
+ *
+ * This calculates the median feed. It sets the current_feed_publication_time
+ * and current_feed member variables
+ *
+ * @param current_time the time to use in the calculations
+ */
 void graphene::chain::asset_bitasset_data_object::update_median_feeds(time_point_sec current_time)
 {
    current_feed_publication_time = current_time;
    vector<std::reference_wrapper<const price_feed>> current_feeds;
+   // find feeds that were alive at current_time
    for( const pair<account_id_type, pair<time_point_sec,price_feed>>& f : feeds )
    {
       if( (current_time - f.second.first).to_seconds() < options.feed_lifetime_sec &&

--- a/libraries/chain/hardfork.d/CORE_890.hf
+++ b/libraries/chain/hardfork.d/CORE_890.hf
@@ -1,0 +1,4 @@
+// bitshares-core issue #890 Update median feeds after feed_lifetime_sec changed
+#ifndef HARDFORK_CORE_890_TIME
+#define HARDFORK_CORE_890_TIME (fc::time_point_sec( 1600000000 ))
+#endif

--- a/tests/tests/bitasset_tests.cpp
+++ b/tests/tests/bitasset_tests.cpp
@@ -489,7 +489,9 @@ BOOST_AUTO_TEST_CASE( hf_890_test )
    generate_blocks(HARDFORK_CORE_890_TIME + maint_interval);
    set_expiration( db, trx );
 
-   // change feed lifetime
+   // change feed lifetime so that some feeds expire,
+   // thereby moving the median feed and causing call orders
+   // to execute
    {
       BOOST_TEST_MESSAGE("Adjust feed lifetime again.");
       asset_update_bitasset_operation ba_op;

--- a/tests/tests/bitasset_tests.cpp
+++ b/tests/tests/bitasset_tests.cpp
@@ -411,6 +411,108 @@ BOOST_AUTO_TEST_CASE( reset_backing_asset_on_non_witness_asset )
    }
 }
 
+/*********
+ * @brief Update median feeds after feed_lifetime_sec changed
+ */
+BOOST_AUTO_TEST_CASE( hf_890_test )
+{
+   BOOST_TEST_MESSAGE("Advance to near hard fork");
+   auto maint_interval = db.get_global_properties().parameters.maintenance_interval;
+   set_expiration( db, trx );
+
+   ACTORS((buyer)(seller)(borrower)(borrower2)(borrower3)(borrower4)(feedproducer));
+
+   const auto& bitusd = create_bitasset("USDBIT", feedproducer_id);
+   const auto& core   = asset_id_type()(db);
+
+   int64_t init_balance(1000000);
+
+   transfer(committee_account, buyer_id, asset(init_balance));
+   transfer(committee_account, borrower_id, asset(init_balance));
+   transfer(committee_account, borrower2_id, asset(init_balance));
+   transfer(committee_account, borrower3_id, asset(init_balance));
+   transfer(committee_account, borrower4_id, asset(init_balance));
+   update_feed_producers( bitusd, {feedproducer.id} );
+
+   BOOST_TEST_MESSAGE("Add a price feed");
+   price_feed current_feed;
+   current_feed.maintenance_collateral_ratio = 1750;
+   current_feed.maximum_short_squeeze_ratio = 1100;
+   current_feed.settlement_price = bitusd.amount( 100 ) / core.amount( 5 );
+   publish_feed( bitusd, feedproducer, current_feed );
+
+   BOOST_TEST_MESSAGE("Place some collateralized orders");
+   // start out with 200% collateral, call price is 10/175 CORE/USD = 40/700
+   const call_order_object& call = *borrow( borrower, bitusd.amount(10), asset(1));
+   call_order_id_type call_id = call.id;
+   // create another position with 310% collateral, call price is 15.5/175 CORE/USD = 62/700
+   const call_order_object& call2 = *borrow( borrower2, bitusd.amount(100000), asset(15500));
+   call_order_id_type call2_id = call2.id;
+   // create yet another position with 350% collateral, call price is 17.5/175 CORE/USD = 77/700
+   const call_order_object& call3 = *borrow( borrower3, bitusd.amount(100000), asset(17500));
+   call_order_id_type call3_id = call3.id;
+   transfer(borrower, seller, bitusd.amount(10));
+   transfer(borrower2, seller, bitusd.amount(100000));
+   transfer(borrower3, seller, bitusd.amount(100000));
+
+   BOOST_TEST_MESSAGE("Adjust price feed to get call order into margin call territory");
+   current_feed.settlement_price = bitusd.amount( 120 ) / core.amount(10);
+   publish_feed( bitusd, feedproducer, current_feed );
+   generate_block();
+   trx.clear();
+   // settlement price = 120 USD / 10 CORE, mssp = 120/11 USD/CORE
+
+   // change feed lifetime
+   {
+      BOOST_TEST_MESSAGE("Adjust feed lifetime");
+      asset_update_bitasset_operation ba_op;
+      const asset_object& asset_to_update = bitusd;
+      ba_op.asset_to_update = bitusd.get_id();
+      ba_op.issuer = asset_to_update.issuer;
+      ba_op.new_options.feed_lifetime_sec = HARDFORK_CORE_890_TIME.sec_since_epoch() + 10;
+      trx.operations.push_back(ba_op);
+      sign(trx, feedproducer_private_key);
+      PUSH_TX(db, trx, ~0);
+      generate_block();
+      trx.clear();
+   }
+   // TODO: make sure median feed updated
+   // check_call_orders() should NOT have been called
+   BOOST_TEST_MESSAGE("No orders should have been filled");
+   BOOST_CHECK( db.find<call_order_object>( call_id ) ); // should not have been filled
+   BOOST_CHECK( db.find<call_order_object>( call2_id ) ); // should not have been filled
+   BOOST_CHECK( db.find<call_order_object>( call3_id ) ); // should not have been filled
+
+
+   // go beyond hardfork
+   BOOST_TEST_MESSAGE("Moving beyond hardfork 890");
+   generate_blocks(HARDFORK_CORE_890_TIME + maint_interval);
+   set_expiration( db, trx );
+
+   // change feed lifetime
+   {
+      BOOST_TEST_MESSAGE("Adjust feed lifetime again.");
+      asset_update_bitasset_operation ba_op;
+      const asset_object& asset_to_update = bitusd;
+      ba_op.asset_to_update = bitusd.get_id();
+      ba_op.issuer = asset_to_update.issuer;
+      ba_op.new_options.feed_lifetime_sec = HARDFORK_CORE_890_TIME.sec_since_epoch() + 20;
+      trx.operations.push_back(ba_op);
+      sign(trx, feedproducer_private_key);
+      PUSH_TX(db, trx, ~0);
+      generate_block();
+      trx.clear();
+   }
+
+   // TODO: make sure median feed updated
+   // TODO: check call orders should have been called
+   BOOST_TEST_MESSAGE("check_call_orders should have been called");
+   BOOST_CHECK( !db.find<call_order_object>( call_id ) ); // should have been filled
+   BOOST_CHECK( !db.find<call_order_object>( call2_id ) ); // should have been filled
+   BOOST_CHECK( !db.find<call_order_object>( call3_id ) ); // should have been filled
+
+}
+
 /*****
  * @brief make sure feeds work correctly after changing from non-witness-fed to witness-fed before the 868 fork
  * NOTE: This test case is a different issue than what is currently being worked on, and fails. Hopefully it


### PR DESCRIPTION
This is a better solution to Bitshares issue #890. This is based on the (safe) assumption that #868 will roll first or at the same time as #890.

* It is based on the branch of Issue #868, thereby removing conflicts
* The logic in update_bitasset_object_options is clearer.

TODO: Need to improve tests